### PR TITLE
fixed bugs with crash and expand

### DIFF
--- a/js/archive_list_contents.js
+++ b/js/archive_list_contents.js
@@ -16,7 +16,8 @@
         jQuery(archive).readmore({
           moreLink: '<a href="#">Expand</a>',
           lessLink: '<a href="#">Close</a>',
-          blockCSS: 'display: none; width: 100%;'
+          blockCSS: 'display: none; width: 100%;',
+          heightMargin: 120,
         });
       });
     }

--- a/src/Plugin/Field/FieldFormatter/ArchiveListContents.php
+++ b/src/Plugin/Field/FieldFormatter/ArchiveListContents.php
@@ -81,7 +81,7 @@ class ArchiveListContents extends FileFormatterBase {
       $element[$delta]['archiveList'] = [
         '#type' => 'container',
         '#attributes' => [
-          'class' => $this->t('archivelist-readmore'),
+          'class' => 'archivelist-readmore',
         ],
       ];
       $element[$delta]['archiveList'][] = [


### PR DESCRIPTION
The crash was fixed by simply removing the translation function from the string,

Close button wasn't functioning after expanding in certain cases when the expanded list was only slightly bigger than the closed list

`blockDisplay: 120`

was added, so if the list is only slightly bigger than the collapsed height, it will just display the whole list.