### PR TITLE
feat: update to reusable workflow

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -8,33 +8,8 @@ on:
   workflow_dispatch:
 
 jobs:
-  build:
-    runs-on: ubuntu-latest
-    continue-on-error: false
-    strategy:
-      fail-fast: false
-      matrix:
-        php-versions: ["8.3", "8.4"]
-        drupal-version: ["10.6", "11.3"] 
-
-    name: PHP ${{ matrix.php-versions }} | Drupal ${{ matrix.drupal-version }}
-
-    steps:
-      - name: Checkout code
-        uses: actions/checkout@v5
-
-      - name: Create docker network
-        run: docker network create ci-default
-
-      - name: PHPUnit tests
-        run: |
-          docker run \
-            --rm \
-            --name drupal \
-            --hostname drupal \
-            --volume $(pwd):/var/www/drupal/web/modules/contrib/$ENABLE_MODULES:ro \
-            --env ENABLE_MODULES \
-            --network ci-default \
-           ghcr.io/islandora/ci:${{ matrix.drupal-version }}-php${{ matrix.php-versions }}
-        env:
-          ENABLE_MODULES: archive_list_contents
+  islandora-module-ci:
+    uses: digitalutsc/reusable_workflows/.github/workflows/islandora-module-ci.yml@main
+    with:
+      module_name: archive_list_contents
+      install_chromedriver: false


### PR DESCRIPTION
# Description
This PR updates to use a reusable workflow, simplifying the setup and maintenance of the workflow.

# Changes
- Replaces the custom `build` job in `.github/workflows/ci.yml` with a call to the `islandora-module-ci` reusable workflow from `digitalutsc/reusable_workflows`, passing in the module name and disabling Chromedriver installation. This removes the explicit matrix, Docker commands, and manual steps, streamlining the workflow configuration.